### PR TITLE
Updated Dockerfile to set different web/smtp ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN npm install && \
 
 ADD . /usr/src/app/
 
-EXPOSE 80 25
+EXPOSE 1080 1025
 
 ENTRYPOINT ["bin/maildev"]
-CMD ["--web", "80", "--smtp", "25"]
+CMD ["--web", "1080", "--smtp", "1025"]
 
 HEALTHCHECK --interval=10s --timeout=1s \
   CMD curl -k -f -v http://localhost/healthz || exit 1


### PR DESCRIPTION
Hi

I've updated the default ports for the web and smtp arguments.

Web now runs on port `1080` and SMTP runs on port `1025`.

Proposed fix for #244